### PR TITLE
Fix: Add error handling for image loading in main_auto.m

### DIFF
--- a/main_auto.m
+++ b/main_auto.m
@@ -10,6 +10,11 @@ clc;
 
 [Imgs, imgs, pixsizes] = tools.load_imgs('images', 1); % load first image in 'images' folder
 
+% Check if images were loaded successfully
+if isempty(Imgs) || isempty(Imgs.fname)
+    error('No valid images found in the "images" folder. Please ensure the folder exists and contains valid image files.');
+end
+
 fname = {Imgs.fname};
 
 


### PR DESCRIPTION
## Problem
The `tools.load_imgs` call in `main_auto.m` does not check for errors. If the 'images' folder is missing or contains no valid images, the script crashes when accessing `Imgs.fname` or passing invalid data to segmentation functions.

## Solution
Added error handling after the `tools.load_imgs` call to:
- Check if `Imgs` structure is empty
- Check if `Imgs.fname` field is empty
- Display a clear error message explaining the issue
- Exit gracefully before attempting to use invalid data

## Testing
The fix should be tested by:
1. Running the script with the 'images' folder missing
2. Running the script with an empty 'images' folder
3. Running the script with invalid/non-image files in the folder
4. Running the script with valid images (should work as before)

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.